### PR TITLE
Change the order of operations.

### DIFF
--- a/tasks/configure_host.yaml
+++ b/tasks/configure_host.yaml
@@ -6,6 +6,6 @@
   shell: chage -I -1 -m 0 -M 99999 -E -1 root
   become: yes
 
-- include_tasks: configure_apt_proxy.yaml
 - include_tasks: install_apt_packages.yaml
 - include_tasks: install_ca_certs.yaml
+- include_tasks: configure_apt_proxy.yaml

--- a/tasks/configure_host.yaml
+++ b/tasks/configure_host.yaml
@@ -6,6 +6,6 @@
   shell: chage -I -1 -m 0 -M 99999 -E -1 root
   become: yes
 
-- include_tasks: install_ca_certs.yaml
 - include_tasks: install_apt_packages.yaml
+- include_tasks: install_ca_certs.yaml
 - include_tasks: configure_apt_proxy.yaml

--- a/tasks/configure_host.yaml
+++ b/tasks/configure_host.yaml
@@ -6,6 +6,6 @@
   shell: chage -I -1 -m 0 -M 99999 -E -1 root
   become: yes
 
-- include_tasks: install_apt_packages.yaml
 - include_tasks: install_ca_certs.yaml
 - include_tasks: configure_apt_proxy.yaml
+- include_tasks: install_apt_packages.yaml

--- a/tasks/configure_host.yaml
+++ b/tasks/configure_host.yaml
@@ -7,5 +7,5 @@
   become: yes
 
 - include_tasks: install_ca_certs.yaml
-- include_tasks: configure_apt_proxy.yaml
 - include_tasks: install_apt_packages.yaml
+- include_tasks: configure_apt_proxy.yaml


### PR DESCRIPTION
apt package install fails after apt proxy setup if the diesel.net CA cert  is not yet installed.